### PR TITLE
break on successful init

### DIFF
--- a/alienfx.c
+++ b/alienfx.c
@@ -276,6 +276,8 @@ int InitDevice(AlienFxType_t *all, AlienFxHandle_t *fxh)
 		libusb_set_debug(fxh->usb_context, 3);
 		int i;
 		for(i = 0 ; i < AlienFxTypesCount ; ++i) {
+			if(succp)
+				break;
 			AlienFxType_t *fxtype = &all[i];
 			if(verbose)
 				printf("scanning for AlienFX type \"%s\"...\n", fxtype->name);
@@ -287,7 +289,7 @@ int InitDevice(AlienFxType_t *all, AlienFxHandle_t *fxh)
 				fxh->info = fxtype;
 				if(verbose)
 					printf("found AlienFX type \"%s\"...\n", fxh->info->name);
-				succp = 1;  /* no break - might be more one - possibly... */
+				succp = 1;
 			}
 		}
 		if(fxh->usb_handle) {


### PR DESCRIPTION
before:
m11x ~ # gdb --args ./alienfx -v color 0 0 0 0x961
...
[New Thread 0x7ffff7fde700 (LWP 22230)]
scanning for AlienFX type "m11x"...
found AlienFX type "m11x"...
scanning for AlienFX type "area51"...
scanning for AlienFX type "allpowerful"...
scanning for AlienFX type "aurora"...
libusb_open_device_with_vid_pid: Resource temporarily unavailable

Program received signal SIGSEGV, Segmentation fault.
0x0000003ea9607b3f in libusb_submit_transfer () from /lib/x86_64-linux-gnu/libusb-1.0.so.0
(gdb) bt

after:
m11x ~ # ./alienfx -v color 0 0 0 0x961
scanning for AlienFX type "m11x"...
found AlienFX type "m11x"...
